### PR TITLE
external_adapter.go: allow setting adapter address from command line

### DIFF
--- a/external_adapter.go
+++ b/external_adapter.go
@@ -29,7 +29,6 @@ type ExternalAdapterData struct {
 	Result int `json:"result"`
 }
 
-const adapterPort = ":6060"
 const jsonHeader = "application/json; charset=UTF-8"
 
 type OkResult struct{}
@@ -40,6 +39,11 @@ var jsonVariableData []byte
 // starts an external adapter on specified port
 func main() {
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+
+	adapterAddress := ":6060"
+	if len(os.Args) > 1 {
+		adapterAddress = os.Args[1]
+	}
 
 	router := httprouter.New()
 	router.GET("/", index)
@@ -55,8 +59,8 @@ func main() {
 	router.POST("/json_variable", jsonVariable)
 	router.POST("/set_json_variable", setJsonVariable)
 
-	log.Info().Str("Port", adapterPort).Msg("Starting external adapter")
-	log.Fatal().AnErr("Error", http.ListenAndServe(adapterPort, router)).Msg("Error occured while running external adapter")
+	log.Info().Str("Address", adapterAddress).Msg("Starting external adapter")
+	log.Fatal().AnErr("Error", http.ListenAndServe(adapterAddress, router)).Msg("Error occured while running external adapter")
 }
 
 // index allows a status check on the adapter


### PR DESCRIPTION
i'm replacing mockserver usage with mock-adapter for chainlink-cosmos and we are currently iterating on the tests locally. my usecase for this is to prevent external users from connecting remotely to mock-adapter when i'm on a public network, and instead  point specifically to a single interface (172.17.0.0/16 for docker mostly) to connect.
